### PR TITLE
Fix the usage of the buffer when we duplicate it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function Buffr (chunks) {
     : this.chunks;
 
   this.on('pipe', this._onPipe.bind(this));
-  if(this.chunks.length) {
+  if(chunks) {
     this.load();
   }
 }


### PR DESCRIPTION
When a buffer is duplicated and when there is no chunks, the buffer will never call `this.push(null)`.

The problem happens on my http-proxy for GET request.
